### PR TITLE
Add chat page, replace discord link

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -87,8 +87,8 @@ export default {
         link: "https://opencollective.com/gbadev",
       },
       {
-        text: "Discord",
-        link: "https://discord.gg/ctGSNxRkg2",
+        text: "Chat",
+        link: "/chat",
       },
       {
         text: "Forum",

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -1,0 +1,52 @@
+# Chat channels
+
+Please take a moment to read the rules before posting:
+
+> 1. _Be nice to each other - we're an easygoing bunch but we won't accept bullying, harassment, or bigotry._
+> 2. _Don't spam, demand attention or send unsolicited private messages._
+> 3. _Don't engage in piracy, or share leaked material (general discussion around such topics is fine)._
+> 4. _No NSFW content, as this community is open to all ages._
+
+You can find us on [Discord](https://discord.gg/ctGSNxRkg2) and [IRC](https://web.libera.chat/?join=#gbadev,#gba-help,#gba-meta,#gba-showcase,#gba-offtopic) (Libera Chat). These two services are bridged together, so take your pick!
+
+The channels are listed below. You will need an IRC client to join them, or use one of the above links.
+
+**Main channels**  
+`#gbadev`          - general chat  
+`#gba-help`        - help & support channel*  
+`#gba-meta`        - community feedback/discussion  
+`#gba-showcase`    - share what you're working on!  
+`#gba-offtopic`    - off-topic chat for everyday stuff  
+
+**Additional channels**  
+`#gba-asm`         - ARM/Thumb assembly and CPU architecture  
+`#gba-emudev`      - emulator development  
+`#gba-graphics`    - pixel art and graphical techniques  
+`#gba-hardware`    - hardware / modding / flashcarts etc.  
+`#gba-matchmaking` - for anyone looking to team up!  
+`#gba-music`       - listening, composing and audio programming  
+`#gba-rust`        - programming for GBA in Rust  
+`#gba-3d`          - 3D graphics programming for GBA  
+`#gba-offtopicdev` - off-topic chat for more technical/programming topics  
+
+**Nintendo DS development**  
+`#dsdev`         - DS homebrew dev chat  
+`#dsdev-help`    - DS help & support channel*  
+
+**GBA Jam**  
+`#gbajam`             - hang out with other jam participants & share your progress  
+`#gbajam-matchmaking` - for anyone looking to team up for the jam  
+
+**Project-specific channels**  
+`#bpcore`          - BPCore Lua game framework development & support  
+`#butano`          - Butano engine development & support  
+`#natu`            - Natu toolkit development & support  
+`#sdk-seven`       - sdk-seven development & support  
+`#gba-docs`        - gbadoc & other community documentation projects  
+`#gba-hhub`        - Homebrew Hub GBA archive discussion  
+`#gba-toolchain`   - gba-toolchain / agbabi / gba-hpp development & support  
+`#gba-tonc`        - Tonc tutorial discussion  
+
+---
+
+\* (there's no such thing as a stupid question!)


### PR DESCRIPTION
This adds a page to the site listing all the IRC channels as well as the community rules. The Discord link in the top bar has been moved to this page.

Closes #8